### PR TITLE
Fix error when `requestIdleCallback` is unsupported

### DIFF
--- a/src/ricTracker.ts
+++ b/src/ricTracker.ts
@@ -49,6 +49,10 @@ class RicTracker {
     }
 
     stop() {
+        if (!this.available) {
+            return
+        }
+
         cancelIdleCallback(this.#idleCallbackId)
         this.#idleCallbackId = undefined
     }


### PR DESCRIPTION
We just started using Main Thread Scheduling and were surprised to find it throwing errors on iOS (it still functions correctly, but no reason to unnecessarily fill the error logs):
```
Can't find variable: cancelIdleCallback
```
It turns out the `RicTracker@start()` function returns if `requestIdleCallback` is unsupported, but `RicTracker@stop()` doesn't.